### PR TITLE
add marlin get attestation tool and action

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,19 @@ Update the address a drift vault is delegated to.
 const signature = await agent.updateDriftVaultDelegate("41Y8C4oxk4zgJT1KXyQr35UhZcfsp5mP86Z2G7UUzojU", "new-address")
 ```
 
+### Get Marlin TEE Attestation
+
+Fetch a remote attestation from a Marlin Oyster Enclave.
+
+```typescript
+// Get attestation from default endpoint (localhost:1350)
+const result = await agent.getMarlinAttestation();
+
+// Or specify a custom endpoint
+const customResult = await agent.getMarlinAttestation("http://127.0.0.1:1800");
+```
+
+
 ## Examples
 
 ### LangGraph Multi-Agent System

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -58,6 +58,7 @@ import withdrawFromDriftAccountAction from "./drift/withdrawFromDriftAccount";
 import driftUserAccountInfoAction from "./drift/driftUserAccountInfo";
 import deriveDriftVaultAddressAction from "./drift/deriveVaultAddress";
 import updateDriftVaultDelegateAction from "./drift/updateDriftVaultDelegate";
+import getAttestationAction from "./marlin/get_attestation";
 
 export const ACTIONS = {
   WALLET_ADDRESS_ACTION: getWalletAddressAction,
@@ -121,6 +122,7 @@ export const ACTIONS = {
   DRIFT_USER_ACCOUNT_INFO_ACTION: driftUserAccountInfoAction,
   DERIVE_DRIFT_VAULT_ADDRESS_ACTION: deriveDriftVaultAddressAction,
   UPDATE_DRIFT_VAULT_DELEGATE_ACTION: updateDriftVaultDelegateAction,
+  GET_MARLIN_ATTESTATION: getAttestationAction,
 };
 
 export type { Action, ActionExample, Handler } from "../types/action";

--- a/src/actions/marlin/get_attestation.ts
+++ b/src/actions/marlin/get_attestation.ts
@@ -1,0 +1,52 @@
+import { Action } from "../../types";
+import { z } from "zod";
+import { getMarlinAttestation } from "../../tools/marlin";
+
+const getAttestationAction: Action = {
+  name: "GET_MARLIN_ATTESTATION",
+  similes: [
+    "get marlin attestation",
+    "fetch marlin attestation",
+    "get oyster attestation",
+  ],
+  description: "Fetches a remote attestation from a Marlin TEE endpoint",
+  examples: [
+    [
+      {
+        input: {},
+        output: {
+          status: "success",
+          message: "Attestation fetched successfully",
+          data: "0x1234...abcd", // Example attestation hex
+        },
+        explanation:
+          "Fetches attestation from default endpoint (localhost:1350)",
+      },
+      {
+        input: { endpoint: "http://custom-endpoint:1350" },
+        output: {
+          status: "success",
+          message: "Attestation fetched successfully",
+          data: "0x5678...efgh", // Example attestation hex
+        },
+        explanation: "Fetches attestation from custom endpoint",
+      },
+    ],
+  ],
+  schema: z.object({
+    endpoint: z
+      .string()
+      .optional()
+      .describe("Optional custom endpoint URL for attestation"),
+  }),
+  handler: async (_, input) => {
+    const attestation = await getMarlinAttestation(input.endpoint);
+    return {
+      status: "success",
+      message: "Attestation fetched successfully",
+      data: attestation,
+    };
+  },
+};
+
+export default getAttestationAction;

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -97,6 +97,7 @@ import {
   withdrawFromDriftUserAccount,
   withdrawFromDriftVault,
   updateVaultDelegate,
+  getMarlinAttestation,
 } from "../tools";
 import {
   Config,
@@ -806,5 +807,8 @@ export class SolanaAgentKit {
   }
   async updateDriftVaultDelegate(vaultAddress: string, delegate: string) {
     return await updateVaultDelegate(this, vaultAddress, delegate);
+  }
+  async getMarlinAttestation() {
+    return await getMarlinAttestation();
   }
 }

--- a/src/langchain/index.ts
+++ b/src/langchain/index.ts
@@ -25,6 +25,7 @@ export * from "./sns";
 export * from "./lightprotocol";
 export * from "./squads";
 export * from "./helius";
+export * from "./marlin";
 
 import { SolanaAgentKit } from "../agent";
 import {
@@ -98,6 +99,7 @@ import {
   SolanaDeleteHeliusWebhookTool,
   SolanaParseTransactionHeliusTool,
   SolanaGetAllAssetsByOwner,
+  MarlinGetAttestationTool,
 } from "./index";
 
 export function createSolanaTools(solanaKit: SolanaAgentKit) {
@@ -177,5 +179,6 @@ export function createSolanaTools(solanaKit: SolanaAgentKit) {
     new SolanaHeliusWebhookTool(solanaKit),
     new SolanaGetHeliusWebhookTool(solanaKit),
     new SolanaDeleteHeliusWebhookTool(solanaKit),
+    new MarlinGetAttestationTool(solanaKit),
   ];
 }

--- a/src/langchain/marlin/get_attestation.ts
+++ b/src/langchain/marlin/get_attestation.ts
@@ -1,0 +1,29 @@
+import { Tool } from "langchain/tools";
+import { SolanaAgentKit } from "../../agent";
+import { getMarlinAttestation } from "../../tools/marlin/get_attestation";
+
+export class MarlinGetAttestationTool extends Tool {
+  name = "marlin_get_attestation";
+  description = "Fetches a remote attestation from a Marlin TEE endpoint";
+
+  constructor(private solanaKit: SolanaAgentKit) {
+    super();
+  }
+
+  protected async _call(input: string): Promise<string> {
+    try {
+      const attestation = await getMarlinAttestation(input || undefined);
+      return JSON.stringify({
+        status: "success",
+        message: "Attestation fetched successfully",
+        data: attestation,
+      });
+    } catch (error: any) {
+      return JSON.stringify({
+        status: "error",
+        message: error.message,
+        code: error.code || "UNKNOWN_ERROR",
+      });
+    }
+  }
+}

--- a/src/langchain/marlin/index.ts
+++ b/src/langchain/marlin/index.ts
@@ -1,0 +1,1 @@
+export * from "./get_attestation";

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -25,3 +25,4 @@ export * from "./tiplink";
 export * from "./lightprotocol";
 export * from "./squads";
 export * from "./helius";
+export * from "./marlin";

--- a/src/tools/marlin/get_attestation.ts
+++ b/src/tools/marlin/get_attestation.ts
@@ -1,0 +1,22 @@
+/**
+ * Fetches a remote attestation from a Marlin TEE endpoint
+ * @param attestationEndpoint Optional endpoint URL, defaults to localhost:1350
+ * @returns The attestation string from the endpoint
+ * @throws Error if the attestation request fails
+ */
+export async function getMarlinAttestation(
+  attestationEndpoint: string = "http://127.0.0.1:1350",
+): Promise<string> {
+  try {
+    const response = await fetch(`${attestationEndpoint}/attestation/hex`);
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch attestation: ${response.statusText}`);
+    }
+
+    return await response.text();
+  } catch (error) {
+    console.error("Failed to fetch Marlin attestation:", error);
+    throw error;
+  }
+}

--- a/src/tools/marlin/index.ts
+++ b/src/tools/marlin/index.ts
@@ -1,0 +1,1 @@
+export * from "./get_attestation";


### PR DESCRIPTION
# Pull Request Description

## Changes Made
This PR adds [Marlin Protocol](https://www.marlin.org/) to Solana Agent Kit. The functionality includes
- Get Attestation from Agent running inside a Marlin TEE Instance
  
## Implementation Details
- Added MarlinGetAttestationTool which by default requests localhost:1350 attestation server to return an oyster image attestation, which can be used to verify/validate the node
- Added the corresponding action

## Transaction executed by agent 
NA

## Prompt Used
```typescript
const action = await findAction("get marlin attestation");
if (!action) {
  throw new Error("Marlin attestation action not found");
}
console.log("Action:", action.name);
const result = await action.handler(agent, {endpoint: "http://localhost:1350"});
console.log("Result:", result);
return result;
```
![image](https://github.com/user-attachments/assets/7f0bae15-4674-412c-9367-2d7d950acd06)

## Checklist
- [x] I have tested these changes locally
- [x] I have updated the documentation
- [ ] I have added a transaction link
- [x] I have added the prompt used to test it 
